### PR TITLE
No shows information subpackages.

### DIFF
--- a/pkgwat/cli/subcommands.py
+++ b/pkgwat/cli/subcommands.py
@@ -37,6 +37,25 @@ class Search(FCommLister):
             start_row=args.start_row,
         )
         rows = result['rows']
+
+        match = False
+        for pkg in rows:
+
+            if pkg['name'] == args.package:
+                match = True
+
+            for sub_pkg in pkg['sub_pkgs']:
+                if sub_pkg['name'] == args.package:
+                    rows[0]['name'] = sub_pkg['name']
+                    rows[0]['description'] = sub_pkg['description']
+                    rows[0]['summary'] = sub_pkg['summary']
+                    rows[0]['link'] = sub_pkg['link']
+                    match = True
+                    break
+
+        if match is False:
+            raise IndexError("No such package found.")
+
         return (
             columns,
             [[row[col] for col in columns] for row in rows],
@@ -64,6 +83,25 @@ class Info(cliff.show.ShowOne):
             raise IndexError("No such package found.")
 
         package = result['rows'][0]
+
+        match = False
+
+        for pkg in result['rows']:
+            if pkg['name'] == args.package:
+                match = True
+
+            for sub_pkg in pkg['sub_pkgs']:
+                if sub_pkg['name'] == args.package:
+                    package['name'] = sub_pkg['name']
+                    package['description'] = sub_pkg['description']
+                    package['summary'] = sub_pkg['summary']
+                    package['name'] = sub_pkg['name']
+                    package['link'] = sub_pkg['link']
+                    match = True
+                    break
+
+        if match is False:
+            raise IndexError("No such package found.")
 
         package['link'] = "https://apps.fedoraproject.org/packages/%s" % \
                 package['link']


### PR DESCRIPTION
When trying to use commands with subpackages, shows parent information package.

pkgwat info ConsoleKit-libs
pkgwat search ConsoleKit-libs

[arielb@infra01 cli]$ pkgwat info ConsoleKit-libs

Starting new HTTPS connection (1): apps.fedoraproject.org
+--------------+-------------------------------------------------------------------+
| Field | Value |
+--------------+-------------------------------------------------------------------+
| upstream_url | http://www.freedesktop.org/wiki/Software/ConsoleKit |
| description | ConsoleKit is a system daemon for tracking what users are logged |
| | into the system and how they interact with the computer (e.g. |
| | which keyboard and mouse they use). |
| | |
| | It provides asynchronous notification via the system message bus. |
| summary | System daemon for tracking users, sessions and seats |
| link | https://apps.fedoraproject.org/packages/ConsoleKit |
| devel_owner | vicodan |
| name | ConsoleKit |
+--------------+-------------------------------------------------------------------+
