### PR TITLE
Add support for querying package relationships - Requires

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,15 +40,16 @@ Getting help::
       --debug        show tracebacks on errors
 
     Commands:
-      bugs           List bugs for a package 
-      builds         List koji builds for a package 
-      changelog      Show the changelog for a package 
-      contents       Show contents of a package 
+      bugs           List bugs for a package
+      builds         List koji builds for a package
+      changelog      Show the changelog for a package
+      contents       Show contents of a package
       help           print detailed help for another command
-      info           Show details about a package 
-      releases       List active releases for a package 
+      info           Show details about a package
+      releases       List active releases for a package
       search         Show a list of packages that match a pattern.
-      updates        List bodhi updates for a package 
+      updates        List bodhi updates for a package
+      dependencies   Show the dependencies for un package
 
 You can search for packages::
 

--- a/pkgwat/cli/subcommands.py
+++ b/pkgwat/cli/subcommands.py
@@ -331,3 +331,37 @@ class Changelog(FCommLister):
             columns,
             [[row[col] for col in columns] for row in rows],
         )
+
+class Dependencies(FCommLister):
+    """Show the dependecies for a package """
+
+    log = logging.getLogger(__name__)
+
+    def take_action(self, args):
+        columns = ['name','provided_by']
+        result = api.dependencies(
+            args.package
+        )
+        if not result['rows']:
+            raise IndexError("No such package found.")
+
+        rows = result['rows']
+
+        show = []
+
+        for row in rows:
+            reg = []
+            reg.append(row['name'])
+            prov_temp = ""
+
+            for prov in row['provided_by']:
+                prov_temp += "- "+prov
+                length = len(row['provided_by'])
+                if length > 1 and (row['provided_by'].index(prov)+1) < length:
+                    prov_temp += "\n"
+
+            if len(prov_temp) > 0:
+                reg.append(prov_temp)
+            show.append(reg)
+            del reg
+        return (columns, show)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ subcommands = [
     'bugs = pkgwat.cli.subcommands:Bugs',
     'contents = pkgwat.cli.subcommands:Contents',
     'changelog = pkgwat.cli.subcommands:Changelog',
+    'dependencies = pkgwat.cli.subcommands:Dependencies',
 ]
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
example using the command
~$pkgwat dependencies pkgwat
Starting new HTTPS connection (1): apps.fedoraproject.org
+--------------------------+-------------------------------+
| name                   | provided_by              |
+--------------------------+-------------------------------+
| python-pkgwat-api | - python-pkgwat-api   |
| python-fabulous    | - python-fabulous       |
| python-cliff           | - python-cliff              |
| python(abi)           | - python                    |
|                            | - python3                  |
| /usr/bin/python     | - python                    |
+-------------------+---------------------------------------+
