### PR TITLE
Show subpackages in search results.

### DIFF
--- a/pkgwat/cli/subcommands.py
+++ b/pkgwat/cli/subcommands.py
@@ -38,11 +38,17 @@ class Search(FCommLister):
             rows_per_page=args.rows_per_page,
             start_row=args.start_row,
         )
-        rows = result['rows']
+
+        final_rows = []
+        for row in result['rows']:
+            final_rows.append(row)
+            for sub_package in row['sub_pkgs']:
+                sub_package['name'] = "  " + sub_package['name']
+                final_rows.append(sub_package)
 
         return (
             columns,
-            [[row[col] for col in columns] for row in rows],
+            [[row[col] for col in columns] for row in final_rows],
         )
 
 


### PR DESCRIPTION
They previously didn't show up at all.

This includes them and also indents them to indicate that they are subpackages.
