### PR TITLE
Default to 'info' command if subcommand not found.

### DIFF
--- a/pkgwat/cli/main.py
+++ b/pkgwat/cli/main.py
@@ -46,9 +46,9 @@ class PkgWat(cliff.app.App):
             self.command_manager.find_command(argv)
         except ValueError as e:
             if "Unknown command" in str(e):
-                print "%r is an unknown command" % ' '.join(argv)
-                print "Try \"pkgwat -h\""
-                sys.exit(1)
+                print("%r is an unknown command" % ' '.join(argv))
+                print("Defaulting to 'info %s'" % ' '.join(argv))
+                return super(PkgWat, self).run_subcommand(['info'] + argv)
             else:
                 raise
 


### PR DESCRIPTION
A lot of times I just want information about a package such as who
owns it and I try to do `pkgwat <the package>` forgetting that I need
`info` before the name. I might be the only one who forgets to do this,
but the patch seemed noninvasive so I decided to make it default to
info.

So now you can do `pkgwat firefox` or just type `firefox` in the pkgwat
REPL. Other commands still work fine, and `info` still works if
specified.
